### PR TITLE
feat,fix/#140/Board & Reply 권한 인가/컨트롤러 수정

### DIFF
--- a/src/main/java/edu/example/dev_2_cc/api_controller/BoardController.java
+++ b/src/main/java/edu/example/dev_2_cc/api_controller/BoardController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,22 +27,34 @@ import java.util.List;
 public class BoardController {
     private final BoardService boardService;
 
+    //-----------------------------------------------게시판----------------------------------------------------
+
+    // Board 단일 조회 -> ADMIN/USER/ANONYMOUS
     @GetMapping("/{boardId}")
     public ResponseEntity<BoardResponseDTO> getBoard(@PathVariable("boardId") Long boardId) {
         return ResponseEntity.ok(boardService.read(boardId));
     }
 
-    @PostMapping
-    public ResponseEntity<BoardResponseDTO> createBoard(@RequestBody BoardRequestDTO boardRequestDTO) {
+    // Board 전체 리스트 조회 -> ADMIN/USER/ANONYMOUS
+    @GetMapping
+    public ResponseEntity<Page<BoardListDTO>> getBoardList(PageRequestDTO pageRequestDTO) {
+        return ResponseEntity.ok(boardService.getList(pageRequestDTO));
+    }
+
+    // Board 등록 -> ADMIN/USER
+    @PostMapping("/") // "/cc/board" 경로는 누구라도 접근 가능하기 때문에 "/"로 비회원 접근 차단
+    public ResponseEntity<BoardResponseDTO> createBoard(@Validated @RequestBody BoardRequestDTO boardRequestDTO) {
         return ResponseEntity.ok(boardService.createBoard(boardRequestDTO));
     }
 
+    // Board 삭제 -> ADMIN/USER
     @DeleteMapping("/{boardId}")
     public ResponseEntity<Map<String, String>> deleteboard(@PathVariable("boardId") Long boardId) {
         boardService.delete(boardId);
         return ResponseEntity.ok(Map.of("message", "Board deleted"));
     }
 
+    // Board 수정 -> ADMIN/USER
     @PutMapping("/{boardId}")
     public ResponseEntity<BoardResponseDTO> updateBoard(@PathVariable Long boardId, @RequestBody BoardUpdateDTO boardUpdateDTO) {
         if(!boardId.equals(boardUpdateDTO.getBoardId())) {
@@ -50,13 +63,8 @@ public class BoardController {
         return ResponseEntity.ok(boardService.updateBoard(boardUpdateDTO));
     }
 
-    @GetMapping
-    public ResponseEntity<Page<BoardListDTO>> getBoardList(PageRequestDTO pageRequestDTO) {
-        return ResponseEntity.ok(boardService.getList(pageRequestDTO));
-    }
-
-    // Member ID로 board 리스트 조회
-    @GetMapping("/listByMember/{memberId}")
+    // Board 멤버 별로 조회 -> ADMIN/USER
+    @GetMapping("/listByMember/{memberId}") // Member ID로 board 리스트 조회
     public ResponseEntity<List<BoardListDTO>> listByMemberId(@Validated @PathVariable("memberId") String memberId) {
         List<BoardListDTO> boards = boardService.listByMemberId(memberId);
         return ResponseEntity.ok(boards);

--- a/src/main/java/edu/example/dev_2_cc/api_controller/BoardFileController.java
+++ b/src/main/java/edu/example/dev_2_cc/api_controller/BoardFileController.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @Log4j2
 @RequestMapping("/cc/boardImage")
 public class BoardFileController {
-    
+
     private final BoardUploadUtil boardUploadUtil;
 
     // 다중 이미지 업로드

--- a/src/main/java/edu/example/dev_2_cc/api_controller/ReplyController.java
+++ b/src/main/java/edu/example/dev_2_cc/api_controller/ReplyController.java
@@ -8,6 +8,7 @@ import edu.example.dev_2_cc.service.ReplyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,40 +23,49 @@ import java.util.Map;
 public class ReplyController {
     private final ReplyService replyService;
 
-    @PostMapping
+    //-----------------------------------------------댓글----------------------------------------------------
+
+    // Reply 등록 -> ADMIN/USER
+    @PostMapping("/")
     public ResponseEntity<ReplyResponseDTO> createReply(@RequestBody ReplyRequestDTO replyRequestDTO) {
         return ResponseEntity.ok(replyService.createReply(replyRequestDTO));
     }
 
+    // Reply 수정 -> ADMIN/USER
     @PutMapping("/{replyId}")
+    @PreAuthorize("@securityUtil.getCurrentUser().memberId == #replyUpdateDTO.memberId or hasRole('ADMIN')") // 작성자 확인
     public ResponseEntity<ReplyResponseDTO> updateReply(@PathVariable Long replyId,
                                                         @Validated @RequestBody ReplyUpdateDTO replyUpdateDTO) {
         return ResponseEntity.ok(replyService.update(replyUpdateDTO));
     }
 
-    // 댓글번호로 조회 기능은 사용하지 않을 확률이 있음
-    @GetMapping("/{replyId}")
-    public ResponseEntity<ReplyResponseDTO> getReply(@PathVariable("replyId") Long replyId) {
-        return ResponseEntity.ok(replyService.read(replyId));
-    }
-
+    // Reply 삭제 -> ADMIN, 해당 댓글 USER, 해당 게시판 USER
     @DeleteMapping("/{replyId}")
+    @PreAuthorize("@replyService.checkDeleteReplyAuthorization(#replyId) or hasRole('ADMIN')") // 댓글 작성자, 보드 작성자 확인
     public ResponseEntity<Map<String, String>> deleteReply(@PathVariable("replyId") Long replyId) {
         replyService.delete(replyId);
         return ResponseEntity.ok(Map.of("message", "Reply deleted"));
     }
 
-    @GetMapping("/listByBoard/{boardId}")
-    public ResponseEntity<List<ReplyListDTO>> listByBoardId(@Validated @PathVariable("boardId") Long boardId) {
-        List<ReplyListDTO> replies = replyService.list(boardId);
-        return ResponseEntity.ok(replies);
-    }
-
-    // Member ID 로 Reply 리스트 조회
+    // Reply 전체 리스트 조회 -> ADMIN/USER
     @GetMapping("/listByMember/{memberId}")
+    @PreAuthorize("#memberId == principal.username or hasRole('ADMIN')") // 작성자 확인
     public ResponseEntity<List<ReplyListDTO>> listByMemberId(@Validated @PathVariable("memberId") String memberId) {
         List<ReplyListDTO> replies = replyService.listByMemberId(memberId);
         return ResponseEntity.ok(replies);
     }
+
+    // 댓글 번호로 댓글 조회기능은 사용하지 않기에 일단 주석처리
+//    @GetMapping("/{replyId}")
+//    public ResponseEntity<ReplyResponseDTO> getReply(@PathVariable("replyId") Long replyId) {
+//        return ResponseEntity.ok(replyService.read(replyId));
+//    }
+
+    // 게시판 번호로 댓글 전체 조회은 이미 게시판 단일 조회에 구현
+//    @GetMapping("/listByBoard/{boardId}")
+//    public ResponseEntity<List<ReplyListDTO>> listByBoardId(@Validated @PathVariable("boardId") Long boardId) {
+//        List<ReplyListDTO> replies = replyService.list(boardId);
+//        return ResponseEntity.ok(replies);
+//    }
 
 }

--- a/src/main/java/edu/example/dev_2_cc/api_controller/advice/APIControllerAdvice.java
+++ b/src/main/java/edu/example/dev_2_cc/api_controller/advice/APIControllerAdvice.java
@@ -33,6 +33,7 @@ public class APIControllerAdvice {
                 .status(e.getCode())   // 예외에서 가져온 상태 코드로 응답 설정
                 .body(errorResponse);  // 커스텀 응답 내용을 body에 담아 반환
     }
+
     @ExceptionHandler(CartTaskException.class)
     public ResponseEntity<?> handleCartException(CartTaskException e) {
         log.info("--- CartTaskException 발생 ---");
@@ -107,4 +108,33 @@ public class APIControllerAdvice {
                 .status(e.getCode())   // 예외에서 가져온 상태 코드로 응답 설정
                 .body(errorResponse);  // 커스텀 응답 내용을 body에 담아 반환
     }
+
+    // 인가 전역 예외 처리
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<?> handleAuthorizationException(AuthorizationException e) {
+        log.info("--- AuthorizationException 발생 ---");
+        log.info("--- e.getClass().getName() : " + e.getClass().getName());
+        log.info("--- e.getMessage() : " + e.getMessage());
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("error message", e.getMessage());
+        errorResponse.put("status", HttpStatus.FORBIDDEN.value()); // 403 Forbidden
+        errorResponse.put("timestamp", LocalDateTime.now());
+
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(errorResponse);
+    }
+
+    // 인가 실패 예외 처리
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<?> handleAccessDeniedException(AccessDeniedException e) {
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("error message", "삭제 할 수 있는 권한이 없습니다.");
+        errorResponse.put("status", HttpStatus.FORBIDDEN.value()); // 403 Forbidden
+        errorResponse.put("timestamp", LocalDateTime.now());
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    }
+
 }

--- a/src/main/java/edu/example/dev_2_cc/config/SecurityConfig.java
+++ b/src/main/java/edu/example/dev_2_cc/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-    //아래에 disabled된 설정들은 jwt에서 개별적으로 설정해줘야 되는 부분이기 때문에 작동해제 시킨다.
+        //아래에 disabled된 설정들은 jwt에서 개별적으로 설정해줘야 되는 부분이기 때문에 작동해제 시킨다.
 
         //csrf disable
         http
@@ -54,13 +54,21 @@ public class SecurityConfig {
         http
                 .httpBasic((auth) -> auth.disable());
 
-        //경로별 인가 작업
+        //경로별 인가 작업 -> 로그인 유무만 따짐 -> 회원 별 식별은 따로 구현 해야함
         http
                 .authorizeHttpRequests((auth) -> auth
-                    .requestMatchers("/login", "/","/cc/member", "/cc/product/**", "/cc/review/**").permitAll()
+                        .requestMatchers("/login", "/",
+                                "/cc/member",
+                                "/cc/product/**",
+                                "/cc/review/**",
+                                "/cc/board",
+                                "/cc/board/{boardId}", // 보드 단일 조회를 위해서 따로 추가
+                                "cc/reply").permitAll()
                         .requestMatchers("/cc/mypage/**").hasRole("USER")
                         .requestMatchers("/cc/admin/**").hasRole("ADMIN")
-                    .anyRequest().authenticated());
+                        // 컨트롤러에서 인가 처리 할때 에러 발생 -> "ROLE_ADMIN" -> "ADMIN"으로 변경
+                        // hasRole 메서드 자체가 "ROLE_"을 붙여준다고 함
+                        .anyRequest().authenticated());
 
         //JWTFilter는 로그인 된 사용자에 대한 토큰 검증 필터이다
         //LoginFilter 앞에서 동작하게 배치하여 JWTFilter가 정상적으로 작동할 경우 로그인이 되어있는 것으로 처리
@@ -76,10 +84,9 @@ public class SecurityConfig {
         //세션 설정
         http
                 .sessionManagement((session) -> session
-                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }
-
 
 }

--- a/src/main/java/edu/example/dev_2_cc/dto/reply/ReplyUpdateDTO.java
+++ b/src/main/java/edu/example/dev_2_cc/dto/reply/ReplyUpdateDTO.java
@@ -8,15 +8,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReplyUpdateDTO {
 
-    private Long replyId;
-
     private String content;
+    private Long replyId;
+    private String memberId; // 작성자,관리자 등 식별을 위한 필드 추가
 
-    public Reply toEntity(){
-        Reply reply = Reply.builder().replyId(replyId).content(content).build();
-
-        return reply;
+    public Reply toEntity() {
+        return Reply.builder()
+                .replyId(replyId)
+                .content(content)
+                .build();
     }
 
 }
-

--- a/src/main/java/edu/example/dev_2_cc/exception/AccessDeniedException.java
+++ b/src/main/java/edu/example/dev_2_cc/exception/AccessDeniedException.java
@@ -1,0 +1,13 @@
+package edu.example.dev_2_cc.exception;
+
+public class AccessDeniedException extends org.springframework.security.access.AccessDeniedException {
+
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+
+    public AccessDeniedException() {
+        super(null); // 메시지를 보낼 필요가 없는 경우 사용하는 기본 생성자
+    }
+
+}

--- a/src/main/java/edu/example/dev_2_cc/exception/AuthorizationException.java
+++ b/src/main/java/edu/example/dev_2_cc/exception/AuthorizationException.java
@@ -1,0 +1,9 @@
+package edu.example.dev_2_cc.exception;
+
+public class AuthorizationException extends RuntimeException {
+
+    public AuthorizationException(String message) {
+        super(message);
+
+    }
+}

--- a/src/main/java/edu/example/dev_2_cc/service/BoardService.java
+++ b/src/main/java/edu/example/dev_2_cc/service/BoardService.java
@@ -4,18 +4,15 @@ import edu.example.dev_2_cc.dto.board.BoardListDTO;
 import edu.example.dev_2_cc.dto.board.BoardRequestDTO;
 import edu.example.dev_2_cc.dto.board.BoardResponseDTO;
 import edu.example.dev_2_cc.dto.board.BoardUpdateDTO;
-import edu.example.dev_2_cc.dto.reply.ReplyListDTO;
 import edu.example.dev_2_cc.dto.review.PageRequestDTO;
 import edu.example.dev_2_cc.entity.Board;
+import edu.example.dev_2_cc.entity.Category;
 import edu.example.dev_2_cc.entity.Member;
-import edu.example.dev_2_cc.entity.Reply;
-import edu.example.dev_2_cc.entity.Review;
+import edu.example.dev_2_cc.exception.AuthorizationException;
 import edu.example.dev_2_cc.exception.BoardException;
 import edu.example.dev_2_cc.exception.MemberException;
-import edu.example.dev_2_cc.exception.ReviewException;
 import edu.example.dev_2_cc.repository.BoardRepository;
-import edu.example.dev_2_cc.repository.MemberRepository;
-import edu.example.dev_2_cc.repository.ProductRepository;
+import edu.example.dev_2_cc.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
@@ -25,60 +22,82 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 @Log4j2
 public class BoardService {
-    private final MemberRepository memberRepository;
+
     private final BoardRepository boardRepository;
+    private final SecurityUtil securityUtil;
 
+    // 게시물 작성
+    @Transactional
     public BoardResponseDTO createBoard(BoardRequestDTO boardRequestDTO) {
-        try {
-            String memberId = boardRequestDTO.getMemberId();
+        // 카테고리 권한 체크
+        checkCategoryAuthorization(boardRequestDTO.getCategory());
 
-            Member member = memberRepository.findById(memberId).orElseThrow();
+        Member currentUser = securityUtil.getCurrentUser();
+//        log.info("아니 큐렌트 유저가 왜?" + currentUser);
 
-            Board board = boardRequestDTO.toEntity(member);
-            Board savedBoard = boardRepository.save(board);
+        // 게시물 생성
+        Board board = Board.builder()
+                .member(currentUser)
+                .title(boardRequestDTO.getTitle())
+                .description(boardRequestDTO.getDescription())
+                .category(boardRequestDTO.getCategory())
+                .build();
 
-            return new BoardResponseDTO(savedBoard);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            throw BoardException.NOT_CREATED.get();
-        }
+        boardRepository.save(board);
+
+        return new BoardResponseDTO(board);
     }
 
-    public BoardResponseDTO updateBoard(BoardUpdateDTO boardUpdateDTO) {
-        Optional<Board> foundBoard = boardRepository.findById(boardUpdateDTO.getBoardId());
-        Board board = foundBoard.orElseThrow(BoardException.NOT_FOUND::get);
-
-        try {
-            board.changeTitle(boardUpdateDTO.getTitle());
-            board.changeDescription(boardUpdateDTO.getDescription());
-            board.changeCategory(boardUpdateDTO.getCategory());
-
-            return new BoardResponseDTO(boardRepository.save(board));
-        }catch (Exception e) {
-            log.error(e.getMessage());
-            throw BoardException.NOT_UPDATED.get();
-        }
-    }
-
+    // 게시물 조회
+    @Transactional(readOnly = true)
     public BoardResponseDTO read(Long boardId) {
-        try {
-            Optional<Board> foundBoard = boardRepository.findById(boardId);
-            Board board = foundBoard.get();
-            return new BoardResponseDTO(board);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            throw BoardException.NOT_FOUND.get();
-        }
+        Board board = boardRepository.findById(boardId).orElseThrow(BoardException.NOT_FOUND::get);
+        return new BoardResponseDTO(board);
     }
 
+    // 게시물 수정
+    @Transactional
+    public BoardResponseDTO updateBoard(BoardUpdateDTO boardUpdateDTO) {
+        Board board = boardRepository.findById(boardUpdateDTO.getBoardId())
+                .orElseThrow(BoardException.NOT_FOUND::get);
+
+        // 권한 체크: 작성자 또는 관리자만 가능
+        securityUtil.checkUserAuthorization(board.getMember());
+
+        // 카테고리 변경 검증: USER는 GENERAL -> TIP, NOTICE로 변경할 수 없음
+        String currentRole = securityUtil.getCurrentUserRole();
+        if ("ROLE_USER".equals(currentRole) && board.getCategory() == Category.GENERAL &&
+                (boardUpdateDTO.getCategory() == Category.TIP || boardUpdateDTO.getCategory() == Category.NOTICE)) {
+            throw new AuthorizationException("USER는 GENERAL 게시물을 TIP 또는 NOTICE로 변경할 수 없습니다.");
+        }
+
+        board.changeTitle(boardUpdateDTO.getTitle());
+        board.changeDescription(boardUpdateDTO.getDescription());
+        board.changeCategory(boardUpdateDTO.getCategory());
+
+        boardRepository.save(board);
+
+        return new BoardResponseDTO(board);
+    }
+
+    // 게시물 삭제
+    @Transactional
+    public void delete(Long boardId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(BoardException.NOT_FOUND::get);
+
+        // 권한 체크: 작성자 또는 관리자만 가능
+        securityUtil.checkUserAuthorization(board.getMember());
+
+        boardRepository.delete(board);
+    }
+
+    @Transactional(readOnly = true)
     public Page<BoardListDTO> getList(PageRequestDTO pageRequestDTO) {
         try {
             Sort sort = Sort.by("createdAt").descending();
@@ -91,20 +110,18 @@ public class BoardService {
         }
     }
 
-    public void delete(Long boardId) {
-        Optional<Board> foundBoard = boardRepository.findById(boardId);
-        Board board = foundBoard.orElseThrow(BoardException.NOT_FOUND::get);
-
-        try{
-            boardRepository.delete(board);
-        }catch (Exception e){
-            log.error("--- " + e.getMessage());
-            throw ReviewException.NOT_DELETED.get();
-        }
-    }
-
-    // Member ID 로 Reply 리스트 조회
+    // MemberID로 Board 리스트 조회
+    @Transactional(readOnly = true)
     public List<BoardListDTO> listByMemberId(String memberId) {
+
+        // 현재 로그인한 사용자의 ID를 가져옴
+        String currentUserId = securityUtil.getCurrentUser().getMemberId();
+
+        // 현재 사용자가 요청한 memberId와 동일한지 확인
+        if (!memberId.equals(currentUserId)) {
+            throw new AuthorizationException("작성자만 자신의 게시물을 조회할 수 있습니다.");
+        }
+
         List<Board> boards = boardRepository.findAllByMember(memberId);
 
         if (boards.isEmpty()) {
@@ -114,6 +131,21 @@ public class BoardService {
         return boards.stream()
                 .map(BoardListDTO::new)
                 .collect(Collectors.toList());
+    }
+
+    // 카테고리 권한 체크 메서드
+    private void checkCategoryAuthorization(Category category) {
+        String currentRole = securityUtil.getCurrentUserRole();
+
+        boolean isAuthorized = switch (category) {
+            case GENERAL -> "ROLE_USER".equals(currentRole) || "ROLE_ADMIN".equals(currentRole);
+            case NOTICE, TIP -> "ROLE_ADMIN".equals(currentRole);
+            default -> false;
+        };
+
+        if (!isAuthorized) {
+            throw new AuthorizationException("카테고리에 대한 권한이 없습니다.");
+        }
     }
 
 }

--- a/src/main/java/edu/example/dev_2_cc/util/SecurityUtil.java
+++ b/src/main/java/edu/example/dev_2_cc/util/SecurityUtil.java
@@ -1,0 +1,78 @@
+package edu.example.dev_2_cc.util;
+
+import edu.example.dev_2_cc.dto.userDetails.CustomUserDetails;
+import edu.example.dev_2_cc.entity.Member;
+import edu.example.dev_2_cc.exception.AuthorizationException;
+import edu.example.dev_2_cc.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class SecurityUtil {
+
+    private final MemberRepository memberRepository;
+
+    // Authentication 객체를 가져오는 메서드 -> 중복되기 때문에 메서드로 합침
+    private Authentication getAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthorizationException("인증 정보가 없습니다.");
+        }
+        return authentication;
+    }
+
+    // 현재 인증된 사용자 정보 가져오기
+    public Member getCurrentUser() {
+        Authentication authentication = getAuthentication();
+//        log.info("아니 어써티케이션이 왜?" + authentication);
+
+        Object principal = authentication.getPrincipal();
+//        log.info("아니 프린시펄가 왜?" + authentication.getPrincipal());
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) principal;
+
+        String memberId;
+        if (principal instanceof UserDetails) {
+            memberId = customUserDetails.getMemberId(); // 인증된 사용자의 이름(아이디)을 가져옴
+        } else if (principal instanceof String) {
+            memberId = (String) principal;
+        } else {
+            throw new AuthorizationException("인증된 사용자 정보를 가져올 수 없습니다.");
+        }
+//        log.info("아니 멤버아이디가 왜?" + memberId);
+
+        // username을 사용하여 Member 엔티티를 가져옴
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthorizationException("사용자를 찾을 수 없습니다."));
+    }
+
+    // 현재 사용자의 역할(Role) 가져오기
+    public String getCurrentUserRole() {
+        Authentication authentication = getAuthentication();
+
+        return authentication.getAuthorities().stream()
+                .findFirst()
+                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                .orElseThrow(() -> new AuthorizationException("권한 정보를 가져올 수 없습니다."));
+    }
+
+    // 현재 사용자가 작성자거나 관리자 인지 확인
+    public void checkUserAuthorization(Member member) {
+        Member currentUser = getCurrentUser();
+        boolean isAuthorized = currentUser.getMemberId().equals(member.getMemberId()) ||
+                "ROLE_ADMIN".equals(getCurrentUserRole());
+
+        if (!isAuthorized) {
+            throw new AuthorizationException("작성자나 관리자만 해당 작업을 수행할 수 있습니다.");
+        }
+    }
+
+}
+
+// authentication.getName()의 반환값은 LoginFilter에서 설정


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘게 쪼개고, Commit 별로 설명해주세요 -->
**1. **Board/Reply 엔드포인트 수정
2. Board 권한 인가 식별(서비스에 구현)
3. Reply 권한 인가 식별(컨트롤러에 구현)
4. 편리한 권한 인가를 위한 SecurityUtil 클래스 추가
5. SecurityConfig 클래스의 경로 인가 수정****

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
